### PR TITLE
Various fixes for issues in Umbraco 7

### DIFF
--- a/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.controller.js
+++ b/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.controller.js
@@ -57,6 +57,9 @@ angular.module("umbraco")
             var cssPath = $scope.model.config.cssPath;
             var cssRegexPattern = $scope.model.config.cssRegex;
             var excludeList = $scope.model.config.excludeList;
+            if (excludeList == null) {
+                excludeList = "";
+            }
             var iconPattern = $scope.model.config.iconPattern;
 
             //validate cssPath & cssRegex supplied
@@ -82,8 +85,10 @@ angular.module("umbraco")
             $http({ method: 'GET', url: cssPath, cache: true }).
   success(function (data, status, headers, config) {
       cssText = data;
-      if (cssRegex.test(cssText)) {
-          hasMatches = true;
+      hasMatches = cssRegex.test(cssText);
+      //reset regex
+      cssRegex.compile(cssRegexPattern, "g");
+      if (hasMatches) {
           var match = cssRegex.exec(cssText);
           matches.push(match[1]);
           while (match != null) {

--- a/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.css
+++ b/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.css
@@ -1,5 +1,5 @@
 
-ul.uCssClassNameIconPicker {min-height: 100px;}
+ul.uCssClassNameIconPicker {max-height: 400px; overflow-y: auto;}
 ul.uCssClassNameIconPicker li {display: inline-block;margin: 0.4em;width: 6em;height: 4em;vertical-align: top;border: 3px solid #ffffff}
 ul.uCssClassNameIconPicker li span {display: block;text-align: center;font-size: 0.8em}
 ul.uCssClassNameIconPicker li a i {font-size: 2em;text-align: center;display: block}

--- a/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.css
+++ b/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpicker.css
@@ -1,5 +1,5 @@
 
-ul.uCssClassNameIconPicker {height: 400px;overflow-x: scroll}
+ul.uCssClassNameIconPicker {min-height: 100px;}
 ul.uCssClassNameIconPicker li {display: inline-block;margin: 0.4em;width: 6em;height: 4em;vertical-align: top;border: 3px solid #ffffff}
 ul.uCssClassNameIconPicker li span {display: block;text-align: center;font-size: 0.8em}
 ul.uCssClassNameIconPicker li a i {font-size: 2em;text-align: center;display: block}

--- a/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpickereditor.html
+++ b/Umbraco7 - Property Editor Version/uCssClassNameIconPicker/ucssclassnameiconpickereditor.html
@@ -6,8 +6,6 @@
 </li>
 
 </ul>
-    <p><i class="currentIcon fa fa-{{model.value}}"></i>
-        <select id="selectClassName" ng-model="model.value" ng-options="ccn for ccn in classnames">      
-        </select></p>
+    
 
     <span ng-bind="info"></span>


### PR DESCRIPTION
This PR fixes a couple of issues I noticed in the Icon Picker in Umbraco 7:
- The first item is not shown. This happens because the `cssRegex.test(cssText);` call moves past the first result. I have added `cssRegex.compile` to reset the regex
- I have reduced the minimum height and set the scrollbar to show only when needed
- I have removed the `select` element, as it seemed to serve no purpose
- I have added a check for when no `excludeList` is set - then it will just be an empty string instead of null